### PR TITLE
Change Android CI run setting

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -3,7 +3,9 @@ name: Android CI
 on:
   push:
     branches: [ "master" ]
-
+  pull_request:
+    branches: [ "master" ]
+  
 jobs:
   build:
 


### PR DESCRIPTION
## Introduction

A fix for the Android CI check of the status checks.

## Background

The previous setting didn't work.

## Status

- **Merge status**: Ready to merge.
- **Real robot test**: GitHub related changes. No need for real robot test.
